### PR TITLE
feat: Add an event to allow defining custom searchable fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Easy Search Changelog
 
+## Unreleased
+### Added
+- Added `\nilsenpaul\easysearch\services\EasySearchService::EVENT_DEFINE_AVAILABLE_FIELDS` 
+  to allow users to register custom searchable fields
+
 ## 1.0.3 - 2021-09-20
 ### Added
 - Added possibility to limit predefined queries to an element source, such as an entry section, category group or asset folder.

--- a/src/events/DefineAvailableFieldsEvent.php
+++ b/src/events/DefineAvailableFieldsEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace nilsenpaul\easysearch\events;
+
+use craft\base\ElementInterface;
+use yii\base\Event;
+
+class DefineAvailableFieldsEvent extends Event
+{
+    /**
+     * @var array An array of associative arrays describing the searchable fields.
+     * Each searchable field must have the following keys: `handle` & `label`.
+     */
+    public $fields;
+
+    /**
+     * @var ElementInterface An (empty) instance of the element type listed in the CP element index page.
+     */
+    public $element;
+}


### PR DESCRIPTION
This allows advanced users to define new searchable fields with the following code in a module for example:

````php
Event::on(
    EasySearchService::class,
    EasySearchService::EVENT_DEFINE_AVAILABLE_FIELDS,
    static function(DefineAvailableFieldsEvent $event) use ($searchableAttributeName) {
        // Add a custom searchable field, only for User elements
        if (!$event->element instanceof User) {
            return;
        }

        $event->fields[] = [
            'handle' => 'customFieldHandle',
            'label'  => 'Custom field'
        ];
    }
);
````